### PR TITLE
Revert "Travis: run pushed-branch hook on master only"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-branches:
-  only:
-  - master
-
 language: python
 python:
 - 2.7


### PR DESCRIPTION
Reverts psychoinformatics-de/brainhack-2018-website#4

Nope. Doesn't work. Now build doesn'T get triggered on merge, too. Clearly in opposition to what https://docs.travis-ci.com/user/web-ui/#Build-pushed-branches says.
